### PR TITLE
deck endpoint utilizes slug

### DIFF
--- a/app/Http/Resources/DeckResource.php
+++ b/app/Http/Resources/DeckResource.php
@@ -15,7 +15,7 @@ class DeckResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-            'name' => $this->resource->name,
+            'slug' => $this->resource->slug,
             'card_count' => $this->resource->cards()->count(),
             'joker_count' => $this->resource->jokers,
         ];

--- a/app/Http/Resources/DeckResource.php
+++ b/app/Http/Resources/DeckResource.php
@@ -15,6 +15,7 @@ class DeckResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
+            'name' => $this->resource->name,
             'slug' => $this->resource->slug,
             'card_count' => $this->resource->cards()->count(),
             'joker_count' => $this->resource->jokers,

--- a/app/Models/Deck.php
+++ b/app/Models/Deck.php
@@ -19,6 +19,16 @@ class Deck extends Model
         'jokers',
     ];
 
+    /**
+     * route identifier is no slug
+     * example: /v1/decks/my-deck
+     * instead of /v1/decks/1
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
     public function cards(): BelongsToMany
     {
         return $this->belongsToMany(Card::class)->withPivot('sequence')

--- a/app/Observers/DeckObserver.php
+++ b/app/Observers/DeckObserver.php
@@ -14,6 +14,11 @@ class DeckObserver
         $deck->initialize();
     }
 
+    public function creating(Deck $deck): void
+    {
+        $deck->slug = str($deck->name)->slug();
+    }
+
     /**
      * Handle the Deck "updated" event.
      */

--- a/database/migrations/2024_09_10_041927_create_decks_table.php
+++ b/database/migrations/2024_09_10_041927_create_decks_table.php
@@ -11,11 +11,11 @@ return new class extends Migration
         Schema::create('decks', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            $table->string('slug')->unique();
             $table->tinyInteger('jokers')->comment('The number of jokers in the deck')->default(0);
             $table->timestamp('updated_at')->useCurrentOnUpdate();
             $table->timestamp('created_at')->useCurrent();
             $table->softDeletes();
-
             $table->unique(['name']);
         });
     }

--- a/database/migrations/2024_09_10_041927_create_decks_table.php
+++ b/database/migrations/2024_09_10_041927_create_decks_table.php
@@ -11,12 +11,12 @@ return new class extends Migration
         Schema::create('decks', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->string('slug')->unique();
+            $table->string('slug');
             $table->tinyInteger('jokers')->comment('The number of jokers in the deck')->default(0);
             $table->timestamp('updated_at')->useCurrentOnUpdate();
             $table->timestamp('created_at')->useCurrent();
             $table->softDeletes();
-            $table->unique(['name']);
+            $table->unique(['name', 'slug']);
         });
     }
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Artisan;
 
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\table;
 use function Laravel\Prompts\text;
 
 Artisan::command('make:user', function () {
@@ -37,12 +36,8 @@ Artisan::command('make:user', function () {
     $user = $userAction->getUser();
     $token = $user->createToken('token-generated-by-make-user')->plainTextToken;
 
-    info('✅ User created successfully!');
-
-    table(
-        ['Name', 'Email', 'API Token'],
-        [[$user->name, $user->email, $token]]
-    );
+    info('✅ User created successfully! Guess what? You get a free API token!');
+    info($token);
 
     info('🔐 Make sure to save the API token, as it won\'t be shown again!');
 });

--- a/tests/Feature/Decks/DeckEndpointTest.php
+++ b/tests/Feature/Decks/DeckEndpointTest.php
@@ -10,15 +10,16 @@ beforeEach(function () {
 
 it('has a valid show endpoint', function () {
     $deck = Deck::factory()->create();
-    $response = $this->getJson('/v1/decks/' . $deck->id);
+    $response = $this->getJson('/v1/decks/' . $deck->slug);
     $response->assertStatus(200);
 });
 
 it('show endpoint includes deck data', function () {
     $deck = Deck::factory()->create();
-    $response = $this->getJson('/v1/decks/' . $deck->id);
+    $response = $this->getJson('/v1/decks/' . $deck->slug);
     $response->assertStatus(200);
     $response->assertJson([
+        'name' => $deck->name,
         'slug' => $deck->slug,
         'card_count' => $deck->cards()->count(),
         'joker_count' => $deck->jokers,

--- a/tests/Feature/Decks/DeckEndpointTest.php
+++ b/tests/Feature/Decks/DeckEndpointTest.php
@@ -14,6 +14,17 @@ it('has a valid show endpoint', function () {
     $response->assertStatus(200);
 });
 
+it('show endpoint includes deck data', function () {
+    $deck = Deck::factory()->create();
+    $response = $this->getJson('/v1/decks/' . $deck->id);
+    $response->assertStatus(200);
+    $response->assertJson([
+        'slug' => $deck->slug,
+        'card_count' => $deck->cards()->count(),
+        'joker_count' => $deck->jokers,
+    ]);
+});
+
 it('can be created over api', function () {
 
     $response = $this->postJson('/v1/decks', [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `slug` identifier for decks, enhancing URL-friendliness and data retrieval.
	- Updated routing to utilize slugs for more descriptive URLs.
	- Simplified user account creation feedback, emphasizing the API token.

- **Bug Fixes**
	- Improved API response to include `slug`, `card_count`, and `joker_count` for deck resources.

- **Tests**
	- Enhanced test coverage for the API show endpoint to verify correct deck data is returned, including the new `slug`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->