### PR TITLE
feature/card response tweak

### DIFF
--- a/app/Http/Resources/CardResource.php
+++ b/app/Http/Resources/CardResource.php
@@ -13,7 +13,7 @@ class CardResource extends JsonResource
     {
         return [
             'rank' => $this->resource->rank,
-            'suit' => $this->resource->suit?->name,
+            'suit' => SuitResource::make($this->resource->suit),
         ];
     }
 }

--- a/tests/Feature/Cards/CardEndpointsTest.php
+++ b/tests/Feature/Cards/CardEndpointsTest.php
@@ -23,6 +23,7 @@ it('can visit index', function () {
 it('can visit show', function () {
     $card = Card::factory()->create();
     $response = $this->getJson('/v1/cards/' . $card->id);
+    $response->assertJson(['rank' => $card->rank, 'suit' => ['name' => $card->suit->name, 'symbol' => $card->suit->symbol, 'color' => $card->suit->color]]);
     $response->assertStatus(200);
 });
 


### PR DESCRIPTION
- **deck endpoint utilizes slug**
- **decks have slug and use them    ❤️**
- **make user:make moor betta**
- **adjust card response**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `slug` field in the Deck resource for improved URL structure.
	- Enhanced the Card resource to represent the 'suit' attribute with a more complex structure.
	- Added automatic slug generation during Deck creation.
- **Bug Fixes**
	- Updated user creation message to directly display the API token instead of in a table format.
- **Tests**
	- Added new assertions to validate the response structure for cards and decks in the API tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->