### PR TITLE
setup base cleanup decks with config value to utilize

### DIFF
--- a/app/Console/Commands/CleanUpDecks.php
+++ b/app/Console/Commands/CleanUpDecks.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class CleanUpDecks extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:clean-up-decks';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        //
+    }
+}

--- a/app/Console/Commands/CleanUpDecks.php
+++ b/app/Console/Commands/CleanUpDecks.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Deck;
 use Illuminate\Console\Command;
 
 class CleanUpDecks extends Command
@@ -11,20 +12,23 @@ class CleanUpDecks extends Command
      *
      * @var string
      */
-    protected $signature = 'app:clean-up-decks';
+    protected $signature = 'decks:clean';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'remove decks at the defined stale threshold';
 
     /**
      * Execute the console command.
      */
     public function handle()
     {
-        //
+        Deck::query()
+            ->where('updated_at', '<', now()
+                ->subHours(config('app.unused_deck_deletion_threshold')))
+            ->delete();
     }
 }

--- a/app/Models/Deck.php
+++ b/app/Models/Deck.php
@@ -8,11 +8,13 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 #[ObservedBy([DeckObserver::class])]
 class Deck extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected $fillable = [
         'name',

--- a/config/app.php
+++ b/config/app.php
@@ -16,6 +16,20 @@ return [
     'name' => env('APP_NAME', 'Laravel'),
 
     /*
+     |--------------------------------------------------------------------------
+     | Unused Deck Deletion Threshold
+     |--------------------------------------------------------------------------
+     |
+     | Deck slugs are unique, so often while testing a number of decks are created
+     | and not utilized. Also, decks might be used but no longer needed. This
+     | value defines the number of hours of inactivity after which an
+     | unused deck will be automatically deleted from the system.
+     |
+     */
+
+    'unused_deck_deletion_threshold' => 24,
+
+    /*
     |--------------------------------------------------------------------------
     | Application Environment
     |--------------------------------------------------------------------------

--- a/database/factories/DeckFactory.php
+++ b/database/factories/DeckFactory.php
@@ -18,7 +18,7 @@ class DeckFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->unique()->word(),
+            'name' => $this->faker->unique()->sentence(),
             'jokers' => 0,
         ];
     }

--- a/routes/console.php
+++ b/routes/console.php
@@ -8,6 +8,7 @@ use function Laravel\Prompts\info;
 use function Laravel\Prompts\spin;
 use function Laravel\Prompts\text;
 
+Schedule::command('decks:clean')->daily();
 Artisan::command('make:user', function () {
     info('🚀 Welcome to the User Creation Wizard! 🚀');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new console command for cleaning up unused decks.
	- Added a configuration option to automatically delete decks after 24 hours of inactivity.
	- Implemented automated daily execution of the deck cleanup command.

- **Bug Fixes**
	- Enabled soft deletion functionality for decks, allowing for recovery of deleted records.

- **Documentation**
	- Provided context in comments regarding the new configuration option for deck deletion.
  
- **Chores**
	- Updated the deck name generation in the factory to produce unique sentences instead of single words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->